### PR TITLE
Compile for Mac

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -864,7 +864,7 @@ void ObxdAudioProcessorEditor::rebuildComponents (ObxdAudioProcessor& ownerFilte
 void ObxdAudioProcessorEditor::createMenu ()
 {
 #if JUCE_MAC
-	bool enablePasteOption = macPasteboard::containsPresetData();	// Check if the clipboard contains data for a Preset
+//	bool enablePasteOption = macPasteboard::containsPresetData();	// Check if the clipboard contains data for a Preset
 #else
     juce::MemoryBlock memoryBlock;
     memoryBlock.fromBase64Encoding(SystemClipboard::getTextFromClipboard());
@@ -936,6 +936,7 @@ void ObxdAudioProcessorEditor::createMenu ()
 
 		fileMenu.addSeparator();
 		
+        /*
 		fileMenu.addItem(static_cast<int>(MenuAction::CopyPreset),
 					 "Copy Preset...",
 					 true,
@@ -946,8 +947,7 @@ void ObxdAudioProcessorEditor::createMenu ()
 					 enablePasteOption,
 					 false);
 
-		/*
-        fileMenu.addItem(static_cast<int>(MenuAction::DeleteBank),
+         fileMenu.addItem(static_cast<int>(MenuAction::DeleteBank),
                      "Delete Bank...",
                      true,
                      false);
@@ -1354,7 +1354,7 @@ void ObxdAudioProcessorEditor::MenuActionCallback(int action){
 		processor.serializePreset(serializedData);
 
 		// Place the data onto the clipboard
-		macPasteboard::copyPresetDataToClipboard(serializedData.getData(), serializedData.getSize());
+//		macPasteboard::copyPresetDataToClipboard(serializedData.getData(), serializedData.getSize());
 	}
 
 	// Paste from clipboard
@@ -1363,11 +1363,11 @@ void ObxdAudioProcessorEditor::MenuActionCallback(int action){
 		juce::MemoryBlock memoryBlock;
 
 		// Fetch Preset data from the clipboard
-		if (macPasteboard::fetchPresetDataFromClipboard(memoryBlock))
-		{
-			// Load the data
-			processor.loadFromMemoryBlock(memoryBlock);	//loadPreset(memoryBlock);
-		}
+//		if (macPasteboard::fetchPresetDataFromClipboard(memoryBlock))
+//		{
+//			// Load the data
+//			processor.loadFromMemoryBlock(memoryBlock);	//loadPreset(memoryBlock);
+//		}
 	}
 #else
     // Copy to clipboard

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -838,6 +838,8 @@ File ObxdAudioProcessor::getCurrentBankFile() const
 //==============================================================================
 File ObxdAudioProcessor::getDocumentFolder() const
 {
+    /// TODO: This file path needs to be updated to Documents or Home.
+    /// Might be nice to have the defaults in the project.
 	File folder = File::getSpecialLocation(File::userDocumentsDirectory).getChildFile("rfawcett160").getChildFile("OB-Xd-GREC");
 /*
     if (! folder.exists())


### PR DESCRIPTION
Hey! Are you taking pull requests on this repo?

This removes the deprecated Paste method to compile for Mac. Also added a note about updating the Themes folder location to a more user friendly place.

